### PR TITLE
Bugfixes for functions and function pointers

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -588,7 +588,7 @@ class Compiler:
 #            case Let(var, rhs, body):
 #                new_body = self.explicate_tail(body, basic_blocks)
 #                return self.explicate_assign(rhs, var, new_body, basic_blocks)
-            case Call(var, args) if not self.is_primitive(var):
+            case Call(var, args) if not self.is_primitive(var) and isinstance(var, FunRef):
                 return [TailCall(var, args)]
             case _:
                 tmp_var = Name(generate_name('expl'))
@@ -962,7 +962,7 @@ class Compiler:
             case Instr("movq", [arg1, arg2]) if arg1 == arg2:
                     return []
             case Instr("leaq", [arg1, Deref(reg, offset)]):
-                return [Instr("movq", [arg1, Reg("rax")]),
+                return [Instr("leaq", [arg1, Reg("rax")]),
                         Instr("movq", [Reg("rax"), Deref(reg, offset)])]
             case TailJump(l, i) if l != Reg("rax"):
                 return [Instr("movq", [l, Reg("rax")]),


### PR DESCRIPTION
Patch instructions:
The second argument of leaq has to be a register. Using movq instead of leaq to rax resulted in segmentation faults and I think it's a bug that has been overlooked from the assignments.

Explicate tail:
Because we can pass functions as arguments to other functions, these arguments will be seen as Name objects and not considered in our reveal function pass, therefore not transformed into FunRefs. This leads to Name objects being used in tailcalls when trying to return the application of a function similar to how it happend with our primitive functions. My idea is to check whether the var in the call is a FunRef or not. If it's not a FunRef the base case will be triggered and with that it works.