### PR TITLE
Runtime patch

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -703,7 +703,25 @@ void print_vector(int64_t* vector_ptr)
 {
   int64_t tag = vector_ptr[0];
   if (is_vecof(tag)) {
-    exit(EXIT_FAILURE); // this could need some love
+    unsigned char len = get_vecof_length(tag);
+    int64_t* scan_ptr = vector_ptr;
+    int64_t* next_ptr = vector_ptr + len + 1;
+
+    printf("%ld=#[", (int64_t)vector_ptr);
+    scan_ptr += 1;
+    int64_t isPointerBit = get_vecof_ptr_bitfield(tag);
+    while (scan_ptr != next_ptr) {
+      if (isPointerBit == 1 && is_ptr((int64_t*)*scan_ptr)) {
+        print_vector(to_ptr((int64_t*)*scan_ptr));
+      } else {
+        printf("%ld", (int64_t)*scan_ptr);
+      }
+      scan_ptr += 1;
+      if (scan_ptr != next_ptr) {
+        printf(", ");
+      }
+    }
+    printf("]");
   } else {
     unsigned char len = get_vector_length(tag);
     int64_t* scan_ptr = vector_ptr;


### PR DESCRIPTION
Arrays (aka. "vecof" / "vectorof") may have been implemented incorrectly in runtime.c.
The identification bit should be at position 62, not 63.
`validate_vector` should not exit with an error when receiving an array pointer.
Even if `print_vector` is never called, the case for arrays was still missing.
The patches are copied from the cases of tuples (aka. "vec").
No guarantee for correctness.