### PR TITLE
Enhancements to test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,295 @@
-*.pyc
-*.o
+## Retained from the original .gitignore
 *.s
-*.out
-*pycache*
-.pytest_cache
-.vscode
 requirements.installed
 mul-div-mod
+
+# Created by https://www.toptal.com/developers/gitignore/api/c,macos,python,venv,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=c,macos,python,venv,visualstudiocode
+
+### C ###
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### venv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+### VisualStudioCode ###
+.vscode/*
+# Ignore settings file
+.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace
+
+# End of https://www.toptal.com/developers/gitignore/api/c,macos,python,venv,visualstudiocode

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ requirements.installed: requirements.txt
 	echo > requirements.installed
 
 run-tests:
-	$(PYTHON3_10) run-tests.py
+	$(PYTHON3_10) run-tests.py -l var -c var tests/var
+	$(PYTHON3_10) run-tests.py -l regalloc -c regalloc tests/regalloc
+	$(PYTHON3_10) run-tests.py -l lif -c lif tests/lif
+	$(PYTHON3_10) run-tests.py -l tuples -c tuples tests/tuples
+	$(PYTHON3_10) run-tests.py -l fun -c fun tests/fun
 
 mul-div-mod.s: mul-div-mod.c
 	gcc -S mul-div-mod.c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
-lark
+click==8.1.3
+lark==1.1.2
+mypy-extensions==0.4.3
+pathspec==0.9.0
+platformdirs==2.5.2
+tomli==2.0.1
+typing_extensions==4.2.0
 graphviz

--- a/run-tests.py
+++ b/run-tests.py
@@ -1,23 +1,96 @@
-import compiler
-import interp_Lfun
-import interp_Cfun
-from type_check_Lexam import TypeCheckLexam
-from interp_Lexam import InterpLexam
-from interp_Cexam import InterpCexam
-import type_check_Lfun
-import type_check_Cfun
-from utils import run_tests, enable_tracing
+import os
 import sys
+from pathlib import Path
 
-sys.setrecursionlimit(10000)
+import click
 
-compiler = compiler.Compiler()
+import compiler
+import interp_Cfun
+import interp_Lfun
+import type_check_Cfun
+import type_check_Lfun
+from utils import enable_tracing, run_one_test, run_tests
 
-if False:
-    enable_tracing()
+_compiler = compiler.Compiler()
 
-run_tests("var", compiler, "var", type_check_Lfun.TypeCheckLfun().type_check, interp_Lfun.InterpLfun().interp, type_check_Cfun.TypeCheckCfun().type_check, interp_Cfun.InterpCfun().interp)
-run_tests("regalloc", compiler, "regalloc", type_check_Lfun.TypeCheckLfun().type_check, interp_Lfun.InterpLfun().interp, type_check_Cfun.TypeCheckCfun().type_check, interp_Cfun.InterpCfun().interp)
-run_tests("lif", compiler, "lif", type_check_Lfun.TypeCheckLfun().type_check, interp_Lfun.InterpLfun().interp, type_check_Cfun.TypeCheckCfun().type_check, interp_Cfun.InterpCfun().interp)
-run_tests("tuples", compiler, "tuples", type_check_Lfun.TypeCheckLfun().type_check, interp_Lfun.InterpLfun().interp, type_check_Cfun.TypeCheckCfun().type_check, interp_Cfun.InterpCfun().interp)
-run_tests("fun", compiler, "fun", type_check_Lfun.TypeCheckLfun().type_check, interp_Lfun.InterpLfun().interp, type_check_Cfun.TypeCheckCfun().type_check, interp_Cfun.InterpCfun().interp)
+
+@click.command()
+@click.option("-l", "--lang", help="Lang to use", required=True, type=str)
+@click.option("-c", "--compiler", help="Compiler to use", required=True, type=str)
+@click.option(
+    "--trace/--no-trace",
+    default=False,
+    show_default=True,
+    help="Enable tracing",
+    type=bool,
+)
+@click.option(
+    "-r",
+    "--recursion-limit",
+    default=10000,
+    show_default=True,
+    help="Change the recursion limit",
+    type=int,
+)
+@click.argument("path", type=click.Path(exists=True))
+def main(lang, compiler, trace, recursion_limit, path):
+    """
+    Runs test(s) found in PATH. If PATH is a directory,
+    script will try to find and run all the tests in it.
+    If it's a file, script will try to run only that single
+    test.
+    """
+    sys.setrecursionlimit(recursion_limit)
+    if trace:
+        enable_tracing()
+
+    p = Path(path)
+    if Path.is_dir(p):
+        run_tests(
+            path=p,
+            lang=lang,
+            compiler=_compiler,
+            compiler_name=compiler,
+            type_check_P=type_check_Lfun.TypeCheckLfun().type_check,
+            interp_P=interp_Lfun.InterpLfun().interp,
+            type_check_C=type_check_Cfun.TypeCheckCfun().type_check,
+            interp_C=interp_Cfun.InterpCfun().interp,
+        )
+    else:
+        succ_passes, tot_passes, succ_test = run_one_test(
+            test=p,
+            lang=lang,
+            compiler=_compiler,
+            compiler_name=compiler,
+            type_check_P=type_check_Lfun.TypeCheckLfun().type_check,
+            interp_P=interp_Lfun.InterpLfun().interp,
+            type_check_C=type_check_Cfun.TypeCheckCfun().type_check,
+            interp_C=interp_Cfun.InterpCfun().interp,
+        )
+        print(
+            "test file: "
+            + str(p)
+        )
+        # Report the pass/fails
+        print(
+            "tests: "
+            + repr(succ_test)
+            + " successful test for compiler "
+            + compiler
+            + " on language "
+            + lang
+        )
+        print(
+            "passes: "
+            + repr(succ_passes)
+            + "/"
+            + repr(tot_passes)
+            + " for compiler "
+            + compiler
+            + " on language "
+            + lang
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/run-tests.py
+++ b/run-tests.py
@@ -67,10 +67,7 @@ def main(lang, compiler, trace, recursion_limit, path):
             type_check_C=type_check_Cfun.TypeCheckCfun().type_check,
             interp_C=interp_Cfun.InterpCfun().interp,
         )
-        print(
-            "test file: "
-            + str(p)
-        )
+        print("test file: " + str(p))
         # Report the pass/fails
         print(
             "tests: "

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,8 @@
 import os
+from pathlib import Path
 import sys
 from sys import platform
 import ast
-from ast import *
 from dataclasses import dataclass
 from typing import Callable
 from filecmp import cmp
@@ -17,275 +17,561 @@ indent_amount = 2
 def indent_stmt():
     return " " * indent_amount
 
+
 def indent():
     global indent_amount
     indent_amount += 2
+
 
 def dedent():
     global indent_amount
     indent_amount -= 2
 
+
 def str_Module(self):
     indent()
-    body = ''.join([str(s) for s in self.body])
+    body = "".join([str(s) for s in self.body])
     dedent()
     return body
-Module.__str__ = str_Module
+
+
+ast.Module.__str__ = str_Module
+
+
 def repr_Module(self):
-    return 'Module(' + repr(self.body) + ')'
-Module.__repr__ = repr_Module
+    return "Module(" + repr(self.body) + ")"
+
+
+ast.Module.__repr__ = repr_Module
+
 
 def str_Expr(self):
-    return indent_stmt() + str(self.value) + '\n'
-Expr.__str__ = str_Expr
+    return indent_stmt() + str(self.value) + "\n"
+
+
+ast.Expr.__str__ = str_Expr
+
+
 def repr_Expr(self):
-    return indent_stmt() + 'Expr(' + repr(self.value) + ')'
-Expr.__repr__ = repr_Expr
+    return indent_stmt() + "Expr(" + repr(self.value) + ")"
+
+
+ast.Expr.__repr__ = repr_Expr
+
 
 def str_Assign(self):
-    return indent_stmt() + str(self.targets[0]) + ' = ' + str(self.value) + '\n'
-Assign.__str__ = str_Assign
+    return indent_stmt() + str(self.targets[0]) + " = " + str(self.value) + "\n"
+
+
+ast.Assign.__str__ = str_Assign
+
+
 def repr_Assign(self):
-    return indent_stmt() + 'Assign(' + repr(self.targets) + ', ' + repr(self.value) + ')'
-Assign.__repr__ = repr_Assign
+    return (
+        indent_stmt() + "Assign(" + repr(self.targets) + ", " + repr(self.value) + ")"
+    )
+
+
+ast.Assign.__repr__ = repr_Assign
+
 
 def str_AnnAssign(self):
-    return indent_stmt() + str(self.target) + ' : ' + str(self.annotation) + ' = ' + str(self.value) + '\n'
-AnnAssign.__str__ = str_AnnAssign
+    return (
+        indent_stmt()
+        + str(self.target)
+        + " : "
+        + str(self.annotation)
+        + " = "
+        + str(self.value)
+        + "\n"
+    )
+
+
+ast.AnnAssign.__str__ = str_AnnAssign
+
+
 def repr_AnnAssign(self):
-    return indent_stmt() + 'AnnAssign(' + repr(self.target) + ', ' \
-        + repr(self.annotation) + ', ' + repr(self.value) + ')'
-AnnAssign.__repr__ = repr_AnnAssign
+    return (
+        indent_stmt()
+        + "AnnAssign("
+        + repr(self.target)
+        + ", "
+        + repr(self.annotation)
+        + ", "
+        + repr(self.value)
+        + ")"
+    )
+
+
+ast.AnnAssign.__repr__ = repr_AnnAssign
+
 
 def str_Return(self):
-    return indent_stmt() + 'return ' + str(self.value) + '\n'
-Return.__str__ = str_Return
+    return indent_stmt() + "return " + str(self.value) + "\n"
+
+
+ast.Return.__str__ = str_Return
+
+
 def repr_Return(self):
-    return indent_stmt() + 'Return(' + repr(self.value) + ')'
-Return.__repr__ = repr_Return
+    return indent_stmt() + "Return(" + repr(self.value) + ")"
+
+
+ast.Return.__repr__ = repr_Return
+
 
 def str_Name(self):
     return self.id
-Name.__str__ = str_Name
+
+
+ast.Name.__str__ = str_Name
+
+
 def repr_Name(self):
-    return 'Name(' + repr(self.id) + ')'
-Name.__repr__ = repr_Name
+    return "Name(" + repr(self.id) + ")"
+
+
+ast.Name.__repr__ = repr_Name
+
 
 def str_Constant(self):
     return str(self.value)
-Constant.__str__ = str_Constant
-def repr_Constant(self):
-    return 'Constant(' + repr(self.value) + ')'
-Constant.__repr__ = repr_Constant
 
-supported_ops = [(Add, '+', 'Add()')
-                ,(Sub, '-', 'Sub()')
-                ,(Mult, '*', 'Mult()')
-                ,(FloorDiv, '//', 'FloorDiv()')
-                ,(Mod, '%', 'Mod()')
-                ,(And, 'and', 'And()')
-                ,(Or, 'or', 'Or()')
-                ,(USub, '-', 'USub()')
-                ,(Not, 'not', 'Not()')]
+
+ast.Constant.__str__ = str_Constant
+
+
+def repr_Constant(self):
+    return "Constant(" + repr(self.value) + ")"
+
+
+ast.Constant.__repr__ = repr_Constant
+
+supported_ops = [
+    (ast.Add, "+", "Add()"),
+    (ast.Sub, "-", "Sub()"),
+    (ast.Mult, "*", "Mult()"),
+    (ast.FloorDiv, "//", "FloorDiv()"),
+    (ast.Mod, "%", "Mod()"),
+    (ast.And, "and", "And()"),
+    (ast.Or, "or", "Or()"),
+    (ast.USub, "-", "USub()"),
+    (ast.Not, "not", "Not()"),
+]
 
 for op_cls, op_name, op_ast_name in supported_ops:
-    op_cls.__str__  = (lambda op_name: lambda self: op_name) (op_name)
-    op_cls.__repr__ = (lambda op_ast_name: lambda self: op_ast_name) (op_ast_name)
+    op_cls.__str__ = (lambda op_name: lambda self: op_name)(op_name)
+    op_cls.__repr__ = (lambda op_ast_name: lambda self: op_ast_name)(op_ast_name)
+
 
 def str_BinOp(self):
-    return '(' + str(self.left) + ' ' + str(self.op) + ' ' + str(self.right) + ')'
-BinOp.__str__ = str_BinOp
+    return "(" + str(self.left) + " " + str(self.op) + " " + str(self.right) + ")"
+
+
+ast.BinOp.__str__ = str_BinOp
+
+
 def repr_BinOp(self):
-    return 'BinOp(' + repr(self.left) + ', ' + repr(self.op) + ', ' + repr(self.right) + ')'
-BinOp.__repr__ = repr_BinOp
+    return (
+        "BinOp("
+        + repr(self.left)
+        + ", "
+        + repr(self.op)
+        + ", "
+        + repr(self.right)
+        + ")"
+    )
+
+
+ast.BinOp.__repr__ = repr_BinOp
+
 
 def str_BoolOp(self):
-    return '(' + str(self.values[0]) + ' ' + str(self.op) + ' ' + str(self.values[1]) + ')'
-BoolOp.__str__ = str_BoolOp
+    return (
+        "(" + str(self.values[0]) + " " + str(self.op) + " " + str(self.values[1]) + ")"
+    )
+
+
+ast.BoolOp.__str__ = str_BoolOp
+
+
 def repr_BoolOp(self):
-    return repr(self.values[0]) + ' ' + repr(self.op) + ' ' + repr(self.values[1])
-BoolOp.__repr__ = repr_BoolOp
+    return repr(self.values[0]) + " " + repr(self.op) + " " + repr(self.values[1])
+
+
+ast.BoolOp.__repr__ = repr_BoolOp
+
 
 def str_UnaryOp(self):
-    return str(self.op) + ' ' + str(self.operand)
-UnaryOp.__str__ = str_UnaryOp
+    return str(self.op) + " " + str(self.operand)
+
+
+ast.UnaryOp.__str__ = str_UnaryOp
+
+
 def repr_UnaryOp(self):
-    return 'UnaryOp(' + repr(self.op) + ', ' + repr(self.operand) + ')'
-UnaryOp.__repr__ = repr_UnaryOp
+    return "UnaryOp(" + repr(self.op) + ", " + repr(self.operand) + ")"
+
+
+ast.UnaryOp.__repr__ = repr_UnaryOp
+
 
 def str_Call(self):
-    return str(self.func) + '(' + ', '.join([str(arg) for arg in self.args]) + ')'
-Call.__str__ = str_Call
+    return str(self.func) + "(" + ", ".join([str(arg) for arg in self.args]) + ")"
+
+
+ast.Call.__str__ = str_Call
+
+
 def repr_Call(self):
-    return 'Call(' + repr(self.func) + ', ' + repr(self.args) + ')'
-Call.__repr__ = repr_Call
+    return "Call(" + repr(self.func) + ", " + repr(self.args) + ")"
+
+
+ast.Call.__repr__ = repr_Call
+
 
 def str_If(self):
-    header = indent_stmt() + 'if ' + str(self.test) + ':\n'
+    header = indent_stmt() + "if " + str(self.test) + ":\n"
     indent()
-    thn = ''.join(str(s) for s in self.body)
-    els = ''.join(str(s) for s in self.orelse)
+    thn = "".join(str(s) for s in self.body)
+    els = "".join(str(s) for s in self.orelse)
     dedent()
-    return header  + thn + indent_stmt() + 'else:\n' + els
-If.__str__ = str_If
+    return header + thn + indent_stmt() + "else:\n" + els
+
+
+ast.If.__str__ = str_If
+
+
 def repr_If(self):
-    return 'If(' + repr(self.test) + ', ' + repr(self.body) + ', ' + repr(self.orelse) + ')'
-If.__repr__ = repr_If
+    return (
+        "If("
+        + repr(self.test)
+        + ", "
+        + repr(self.body)
+        + ", "
+        + repr(self.orelse)
+        + ")"
+    )
+
+
+ast.If.__repr__ = repr_If
+
 
 def str_IfExp(self):
-    return '(' + str(self.body) + ' if ' + str(self.test) + ' else ' + str(self.orelse) + ')'
-IfExp.__str__ = str_IfExp
+    return (
+        "("
+        + str(self.body)
+        + " if "
+        + str(self.test)
+        + " else "
+        + str(self.orelse)
+        + ")"
+    )
+
+
+ast.IfExp.__str__ = str_IfExp
+
+
 def repr_IfExp(self):
-    return 'IfExp(' + repr(self.body) + ', ' + repr(self.test) + ', ' + repr(self.orelse) + ')'
-IfExp.__repr__ = repr_IfExp
+    return (
+        "IfExp("
+        + repr(self.body)
+        + ", "
+        + repr(self.test)
+        + ", "
+        + repr(self.orelse)
+        + ")"
+    )
+
+
+ast.IfExp.__repr__ = repr_IfExp
+
 
 def str_While(self):
-    header = indent_stmt() + 'while ' + str(self.test) + ':\n'
+    header = indent_stmt() + "while " + str(self.test) + ":\n"
     indent()
-    body = ''.join(str(s) for s in self.body)
+    body = "".join(str(s) for s in self.body)
     dedent()
     return header + body
-While.__str__ = str_While
+
+
+ast.While.__str__ = str_While
+
+
 def repr_While(self):
-    return 'While(' + repr(self.test) + ', ' + repr(self.body) + ', ' + repr(self.orelse) + ')'
-While.__repr__ = repr_While
+    return (
+        "While("
+        + repr(self.test)
+        + ", "
+        + repr(self.body)
+        + ", "
+        + repr(self.orelse)
+        + ")"
+    )
+
+
+ast.While.__repr__ = repr_While
+
 
 def str_Compare(self):
-    return str(self.left) + ' ' + str(self.ops[0]) + ' ' + str(self.comparators[0])
-Compare.__str__ = str_Compare
+    return str(self.left) + " " + str(self.ops[0]) + " " + str(self.comparators[0])
+
+
+ast.Compare.__str__ = str_Compare
+
+
 def repr_Compare(self):
-    return 'Compare(' + repr(self.left) + ', ' + repr(self.ops) + ', ' + repr(self.comparators) + ')'
-Compare.__repr__ = repr_Compare
+    return (
+        "Compare("
+        + repr(self.left)
+        + ", "
+        + repr(self.ops)
+        + ", "
+        + repr(self.comparators)
+        + ")"
+    )
+
+
+ast.Compare.__repr__ = repr_Compare
+
 
 def str_Eq(self):
-    return '=='
-Eq.__str__ = str_Eq
+    return "=="
+
+
+ast.Eq.__str__ = str_Eq
+
+
 def repr_Eq(self):
-    return 'Eq()'
-Eq.__repr__ = repr_Eq
+    return "Eq()"
+
+
+ast.Eq.__repr__ = repr_Eq
+
 
 def str_NotEq(self):
-    return '!='
-NotEq.__str__ = str_NotEq
+    return "!="
+
+
+ast.NotEq.__str__ = str_NotEq
+
+
 def repr_NotEq(self):
-    return 'NotEq()'
-NotEq.__repr__ = repr_NotEq
+    return "NotEq()"
+
+
+ast.NotEq.__repr__ = repr_NotEq
+
 
 def str_Lt(self):
-    return '<'
-Lt.__str__ = str_Lt
+    return "<"
+
+
+ast.Lt.__str__ = str_Lt
+
+
 def repr_Lt(self):
-    return 'Lt()'
-Lt.__repr__ = repr_Lt
+    return "Lt()"
+
+
+ast.Lt.__repr__ = repr_Lt
+
 
 def str_LtE(self):
-    return '<='
-LtE.__str__ = str_Lt
+    return "<="
+
+
+ast.LtE.__str__ = str_Lt
+
+
 def repr_LtE(self):
-    return 'LtE()'
-LtE.__repr__ = repr_LtE
+    return "LtE()"
+
+
+ast.LtE.__repr__ = repr_LtE
+
 
 def str_Gt(self):
-    return '>'
-Gt.__str__ = str_Gt
+    return ">"
+
+
+ast.Gt.__str__ = str_Gt
+
+
 def repr_Gt(self):
-    return 'Gt()'
-Gt.__repr__ = repr_Gt
+    return "Gt()"
+
+
+ast.Gt.__repr__ = repr_Gt
+
 
 def str_GtE(self):
-    return '>='
-GtE.__str__ = str_GtE
+    return ">="
+
+
+ast.GtE.__str__ = str_GtE
+
+
 def repr_GtE(self):
-    return 'GtE()'
-GtE.__repr__ = repr_GtE
+    return "GtE()"
+
+
+ast.GtE.__repr__ = repr_GtE
+
 
 def str_Tuple(self):
-    return '(' + ', '.join(str(e) for e in self.elts)  + ',)'
-Tuple.__str__ = str_Tuple
+    return "(" + ", ".join(str(e) for e in self.elts) + ",)"
+
+
+ast.Tuple.__str__ = str_Tuple
+
+
 def repr_Tuple(self):
-    return 'Tuple(' + repr(self.elts) + ')'
-Tuple.__repr__ = repr_Tuple
+    return "Tuple(" + repr(self.elts) + ")"
+
+
+ast.Tuple.__repr__ = repr_Tuple
+
 
 def str_List(self):
-    return '[' + ', '.join(str(e) for e in self.elts)  + ',]'
-List.__str__ = str_List
+    return "[" + ", ".join(str(e) for e in self.elts) + ",]"
+
+
+ast.List.__str__ = str_List
+
+
 def repr_List(self):
-    return 'List[' + repr(self.elts) + ']'
-List.__repr__ = repr_List
+    return "List[" + repr(self.elts) + "]"
+
+
+ast.List.__repr__ = repr_List
+
 
 def str_Subscript(self):
-    return str(self.value) + '[' + str(self.slice) + ']'
-Subscript.__str__ = str_Subscript
+    return str(self.value) + "[" + str(self.slice) + "]"
+
+
+ast.Subscript.__str__ = str_Subscript
+
+
 def repr_Subscript(self):
-    return 'Subscript(' + repr(self.value) + ', ' + repr(self.slice) + ', ' + repr(self.ctx) + ')'
-Subscript.__repr__ = repr_Subscript
+    return (
+        "Subscript("
+        + repr(self.value)
+        + ", "
+        + repr(self.slice)
+        + ", "
+        + repr(self.ctx)
+        + ")"
+    )
+
+
+ast.Subscript.__repr__ = repr_Subscript
 
 
 def str_FunctionDef(self):
+    body = ""
     if isinstance(self.args, ast.arguments):
-        params = ', '.join(a.arg + ':' + str(a.annotation) for a in self.args.args)
+        params = ", ".join(a.arg + ":" + str(a.annotation) for a in self.args.args)
     else:
-        params = ', '.join(x + ':' + str(t) for (x,t) in self.args)
+        params = ", ".join(x + ":" + str(t) for (x, t) in self.args)
     indent()
     if isinstance(self.body, list):
-        body = ''.join(str(s) for s in self.body)
+        body = "".join(str(s) for s in self.body)
     elif isinstance(self.body, dict):
-        body = ''
-        for (l,ss) in self.body.items():
-            body += l + ':\n'
+        body = ""
+        for (l, ss) in self.body.items():
+            body += l + ":\n"
             indent()
-            body += ''.join(str(s) for s in ss)
+            body += "".join(str(s) for s in ss)
             dedent()
     dedent()
-    return indent_stmt() + 'def ' + self.name + '(' + params + ')' + \
-        ' -> ' + str(self.returns) + ':\n' + body + '\n'
+    return (
+        indent_stmt()
+        + "def "
+        + self.name
+        + "("
+        + params
+        + ")"
+        + " -> "
+        + str(self.returns)
+        + ":\n"
+        + body
+        + "\n"
+    )
+
+
 def repr_FunctionDef(self):
-    return 'FunctionDef(' + self.name + ',' + repr(self.args) + ',' + \
-        repr(self.body) + ')'
-FunctionDef.__str__ = str_FunctionDef
-FunctionDef.__repr__ = repr_FunctionDef
+    return (
+        "FunctionDef(" + self.name + "," + repr(self.args) + "," + repr(self.body) + ")"
+    )
+
+
+ast.FunctionDef.__str__ = str_FunctionDef
+ast.FunctionDef.__repr__ = repr_FunctionDef
+
 
 def str_Lambda(self):
     if isinstance(self.args, ast.arguments):
-        params = ', '.join(a.arg for a in self.args.args)
+        params = ", ".join(a.arg for a in self.args.args)
     else:
-        params = ', '.join(self.args)
+        params = ", ".join(self.args)
     body = str(self.body)
-    return '(lambda ' + params + ': ' + body + ')'
+    return "(lambda " + params + ": " + body + ")"
+
+
 def repr_Lambda(self):
-    return 'Lambda(' + repr(self.args) + ',' + repr(self.body) + ')'
-Lambda.__str__ = str_Lambda
-Lambda.__repr__ = repr_Lambda
-    
+    return "Lambda(" + repr(self.args) + "," + repr(self.body) + ")"
+
+
+ast.Lambda.__str__ = str_Lambda
+ast.Lambda.__repr__ = repr_Lambda
+
 
 ################################################################################
 # __eq__ and __hash__ for classes in the ast module
 ################################################################################
 
+
 def eq_Name(self, other):
-    if isinstance(other, Name):
+    if isinstance(other, ast.Name):
         return self.id == other.id
     else:
         return False
-Name.__eq__ = eq_Name
+
+
+ast.Name.__eq__ = eq_Name
+
 
 def hash_Name(self):
     return hash(self.id)
-Name.__hash__ = hash_Name
+
+
+ast.Name.__hash__ = hash_Name
 
 ################################################################################
 # map compare operators to their encoding
 # could be done as a dictionary, but there is neither __hash__ nor __eq__
 ################################################################################
 
+
 def cmp_to_code(cmp) -> str:
     match cmp:
-        case Eq(): return 'e'
-        case NotEq(): return 'ne'
-        case Lt(): return 'l'
-        case LtE(): return 'le'
-        case Gt(): return 'g'
-        case GtE(): return 'ge'
+        case ast.Eq():
+            return "e"
+        case ast.NotEq():
+            return "ne"
+        case ast.Lt():
+            return "l"
+        case ast.LtE():
+            return "le"
+        case ast.Gt():
+            return "g"
+        case ast.GtE():
+            return "ge"
+        case _:
+            raise Exception("can't match cmp_to_code: " + cmp)
+
 
 ################################################################################
 # Generating unique names
@@ -293,23 +579,26 @@ def cmp_to_code(cmp) -> str:
 
 name_id = 0
 
+
 def generate_name(name):
     global name_id
-    ls = name.split('.')
+    ls = name.split(".")
     new_id = name_id
     name_id += 1
-    return ls[0] + '.' + str(new_id)
+    return ls[0] + "." + str(new_id)
 
 
 ################################################################################
 # AST classes
 ################################################################################
 
-Binding = tuple[Name, expr]
+Binding = tuple[ast.Name, ast.expr]
 Temporaries = list[Binding]
+
 
 class Type:
     pass
+
 
 # Obsolete, use Begin instead. -Jeremy
 # @dataclass
@@ -329,227 +618,315 @@ class Type:
 #         result = Let(x, rhs, result)
 #     return result
 
-def make_assigns(bs: Temporaries) -> list[stmt]:
-    return [Assign([x], rhs) for (x,rhs) in bs]
 
-def make_begin(bs: Temporaries, e: expr) -> expr:
+def make_assigns(bs: Temporaries) -> list[ast.stmt]:
+    return [ast.Assign([x], rhs) for (x, rhs) in bs]
+
+
+def make_begin(bs: Temporaries, e: ast.expr) -> ast.expr:
     if len(bs) > 0:
         return Begin(make_assigns(bs), e)
     else:
         return e
 
+
 # A lambda expression whose parameters are annotated with types.
 @dataclass
-class AnnLambda(expr):
-    params : list[tuple[str,Type]]
-    returns : Type
-    body : expr
+class AnnLambda(ast.expr):
+    params: list[tuple[str, Type]]
+    returns: Type
+    body: ast.expr
+
     def __str__(self):
-        return 'lambda [' + \
-            ', '.join([x + ':' + str(t) for (x,t) in self.params]) + '] -> ' \
-            + str(self.returns) + ': ' + str(self.body)
+        return (
+            "lambda ["
+            + ", ".join([x + ":" + str(t) for (x, t) in self.params])
+            + "] -> "
+            + str(self.returns)
+            + ": "
+            + str(self.body)
+        )
+
 
 # An uninitialized value of a given type.
 # Needed for boxing local variables.
 @dataclass
-class Uninitialized(expr):
-    ty : Type
-    def __str__(self):
-        return 'uninit[' + str(self.ty) + ']'
-    
-@dataclass
-class CProgram:
-    body : list[stmt]
+class Uninitialized(ast.expr):
+    ty: Type
 
     def __str__(self):
-        result = ''
-        for (l,ss) in self.body.items():
-            result += l + ':\n'
+        return "uninit[" + str(self.ty) + "]"
+
+
+@dataclass
+class CProgram:
+    body: list[ast.stmt]
+
+    def __str__(self):
+        result = ""
+        for l, ss in self.body:  # type: ignore
+            result += l + ":\n"
             indent()
-            result += ''.join([str(s) for s in ss]) + '\n'
+            result += "".join([str(s) for s in ss]) + "\n"
             dedent()
         return result
 
+
 @dataclass
 class CProgramDefs:
-    defs : list[stmt]
+    defs: list[ast.stmt]
+
     def __str__(self):
-        return '\n'.join([str(d) for d in self.defs]) + '\n'
-    
-@dataclass
-class Goto(stmt):
-    label : str
-    def __str__(self):
-        return indent_stmt() + 'goto ' + self.label + '\n'
+        return "\n".join([str(d) for d in self.defs]) + "\n"
+
 
 @dataclass
-class Allocate(expr):
-    length : int
-    ty : Type
+class Goto(ast.stmt):
+    label: str
+
     def __str__(self):
-        return 'allocate(' + str(self.length) + ',' + str(self.ty) + ')'
+        return indent_stmt() + "goto " + self.label + "\n"
+
 
 @dataclass
-class AllocateClosure(expr):
-    length : int
-    ty : Type
-    arity : int
+class Allocate(ast.expr):
+    length: int
+    ty: Type
+
     def __str__(self):
-        return 'alloc_clos(' + str(self.length) + ',' + str(self.ty) \
-            + ','  + str(self.arity) + ')'
+        return "allocate(" + str(self.length) + "," + str(self.ty) + ")"
+
 
 @dataclass
-class AllocateArray(expr):
-    length : expr
-    ty : Type
+class AllocateClosure(ast.expr):
+    length: int
+    ty: Type
+    arity: int
+
     def __str__(self):
-        return 'alloc_array(' + str(self.length) + ',' + str(self.ty) + ')'
+        return (
+            "alloc_clos("
+            + str(self.length)
+            + ","
+            + str(self.ty)
+            + ","
+            + str(self.arity)
+            + ")"
+        )
+
 
 @dataclass
-class Collect(stmt):
-    size : int
+class AllocateArray(ast.expr):
+    length: ast.expr
+    ty: Type
+
     def __str__(self):
-        return indent_stmt() + 'collect(' + str(self.size) + ')\n'
+        return "alloc_array(" + str(self.length) + "," + str(self.ty) + ")"
+
 
 @dataclass
-class CollectArray(stmt):
-    size : expr
+class Collect(ast.stmt):
+    size: int
+
     def __str__(self):
-        return indent_stmt() + 'collect_array(' + str(self.size) + ')\n'
-    
+        return indent_stmt() + "collect(" + str(self.size) + ")\n"
+
+
 @dataclass
-class Begin(expr):
-    body : list[stmt]
-    result : expr
+class CollectArray(ast.stmt):
+    size: ast.expr
+
+    def __str__(self):
+        return indent_stmt() + "collect_array(" + str(self.size) + ")\n"
+
+
+@dataclass
+class Begin(ast.expr):
+    body: list[ast.stmt]
+    result: ast.expr
+
     def __str__(self):
         indent()
-        stmts = ''.join([str(s) for s in self.body])
-        end = indent_stmt() + 'produce ' + str(self.result)
+        stmts = "".join([str(s) for s in self.body])
+        end = indent_stmt() + "produce " + str(self.result)
         dedent()
-        return '{\n' + stmts + end + '}'
+        return "{\n" + stmts + end + "}"
+
 
 @dataclass
-class GlobalValue(expr):
-    name : str
+class GlobalValue(ast.expr):
+    name: str
+
     def __str__(self):
         return str(self.name)
+
 
 @dataclass(eq=True)
 class IntType(Type):
     def __str__(self):
-        return 'int'
+        return "int"
+
 
 @dataclass(eq=True)
 class BoolType(Type):
     def __str__(self):
-        return 'bool'
+        return "bool"
+
 
 @dataclass(eq=True)
 class VoidType(Type):
     def __str__(self):
-        return 'void'
-    
+        return "void"
+
+
 @dataclass(eq=True)
 class Bottom(Type):
     def __str__(self):
-        return 'bottom'
+        return "bottom"
+
 
 @dataclass(eq=True)
 class TupleType(Type):
-    types : list[Type]
+    types: list[Type]
+
     def __str__(self):
-        return 'tuple[' + ','.join(map(str, self.types)) + ']'
+        return "tuple[" + ",".join(map(str, self.types)) + "]"
+
 
 @dataclass(eq=True)
 class FunctionType:
-    param_types : list[Type]
-    ret_type : Type
+    param_types: list[Type]
+    ret_type: Type
+
     def __str__(self):
-        return 'Callable[[' + ','.join(map(str, self.param_types))+']'\
-            + ', ' + str(self.ret_type) + ']'
+        return (
+            "Callable[["
+            + ",".join(map(str, self.param_types))
+            + "]"
+            + ", "
+            + str(self.ret_type)
+            + "]"
+        )
+
 
 @dataclass(eq=True)
 class ListType(Type):
-    elt_ty : Type
+    elt_ty: Type
+
     def __str__(self):
-        return 'list[' + str(self.elt_ty) + ']'
-    
+        return "list[" + str(self.elt_ty) + "]"
+
+
 @dataclass
-class FunRef(expr):
-    name : str
-    arity : int
+class FunRef(ast.expr):
+    name: str
+    arity: int
+
     def __str__(self):
-        return '{' + self.name + '}'
-    
+        return "{" + self.name + "}"
+
+
 @dataclass
-class TailCall(stmt):
-    func : expr
-    args : list[expr]
+class TailCall(ast.stmt):
+    func: ast.expr
+    args: list[ast.expr]
+
     def __str__(self):
-        return indent_stmt() + 'tail ' + str(self.func) + '(' + ', '.join([str(e) for e in self.args]) + ')\n'
+        return (
+            indent_stmt()
+            + "tail "
+            + str(self.func)
+            + "("
+            + ", ".join([str(e) for e in self.args])
+            + ")\n"
+        )
+
 
 # like a Tuple, but also stores the function's arity
 @dataclass
-class Closure(expr):
-    arity : int
-    args : list[expr]
+class Closure(ast.expr):
+    arity: int
+    args: list[ast.expr]
     __match_args__ = ("arity", "args")
+
     def __str__(self):
-        return 'closure[' + repr(self.arity) + '](' + ', '.join([str(e) for e in self.args]) + ')'
+        return (
+            "closure["
+            + repr(self.arity)
+            + "]("
+            + ", ".join([str(e) for e in self.args])
+            + ")"
+        )
+
 
 @dataclass
-class Inject(expr):
-    value : expr
-    typ : Type
+class Inject(ast.expr):
+    value: ast.expr
+    typ: Type
     __match_args__ = ("value", "typ")
+
     def __str__(self):
-        return 'inject(' + str(self.value) + ', ' + str(self.typ) + ')'
+        return "inject(" + str(self.value) + ", " + str(self.typ) + ")"
+
 
 @dataclass
-class Project(expr):
-    value : expr
-    typ : Type
+class Project(ast.expr):
+    value: ast.expr
+    typ: Type
     __match_args__ = ("value", "typ")
+
     def __str__(self):
-        return 'project(' + str(self.value) + ', ' + str(self.typ) + ')'
-    
+        return "project(" + str(self.value) + ", " + str(self.typ) + ")"
+
+
 @dataclass
-class TagOf(expr):
-    value : expr
+class TagOf(ast.expr):
+    value: ast.expr
     __match_args__ = ("value",)
+
     def __str__(self):
-        return 'tagof(' + str(self.value) + ')'
+        return "tagof(" + str(self.value) + ")"
+
 
 @dataclass
-class ValueOf(expr):
-    value : expr
-    typ : Type
-    __match_args__ = ("value","typ")
+class ValueOf(ast.expr):
+    value: ast.expr
+    typ: Type
+    __match_args__ = ("value", "typ")
+
     def __str__(self):
-        return 'valueof(' + str(self.value) + ', ' + str(self.typ) + ')'
-    
+        return "valueof(" + str(self.value) + ", " + str(self.typ) + ")"
+
+
 @dataclass(eq=True)
 class AnyType(Type):
     def __str__(self):
-        return 'any'
+        return "any"
+
 
 # Base class of runtime values
 class Value:
     pass
 
+
 block_id = 0
 
-def create_block(stmts: list[stmt], basic_blocks:dict[str,list[stmt]]) -> Goto:
-    'stuff statments into a new basic block; return a jump to it'
+
+def create_block(
+    stmts: list[ast.stmt], basic_blocks: dict[str, list[ast.stmt]]
+) -> Goto:
+    "stuff statments into a new basic block; return a jump to it"
     global block_id
-    label = 'block' + str(block_id)
+    label = "block" + str(block_id)
     block_id += 1
     basic_blocks[label_name(label)] = stmts
     return Goto(label)
-    
+
+
 ################################################################################
 # Miscellaneous Auxiliary Functions
 ################################################################################
+
 
 def input_int() -> int:
     return int(input())
@@ -569,29 +946,36 @@ def align(n: int, alignment: int) -> int:
     else:
         return n + (alignment - n % alignment)
 
+
 def bool2int(b):
     if b:
         return 1
     else:
         return 0
 
-label_name: Callable[[str], str] = (lambda n: '_' + n) if platform == 'darwin' else (lambda n: n)
+
+label_name: Callable[[str], str] = (
+    (lambda n: "_" + n) if platform == "darwin" else (lambda n: n)
+)
 
 # def label_name(n: str) -> str:
 #     if platform == "darwin":
 #         return '_' + n
 #     else:
 #         return n
-    
+
 tracing = False
+
 
 def enable_tracing():
     global tracing
     tracing = True
 
+
 def trace(msg):
     if tracing:
         print(msg, file=sys.stderr)
+
 
 def is_python_extension(filename):
     s = filename.split(".")
@@ -600,37 +984,41 @@ def is_python_extension(filename):
     else:
         return False
 
-def ensure_final_newline(filename):
+
+def ensure_final_newline(filename: Path):
     # check whether file is empty
     if os.stat(filename).st_size != 0:
         with open(filename, "r+b") as f:
             # must open as b to seek from end; read last character
             f.seek(-1, 2)
             b = f.read(1)
-            newline = bytes('\n', 'utf-8')
+            newline = bytes("\n", "utf-8")
             if b != newline:
                 f.write(newline)
 
 
-compare_files = lambda file1, file2: cmp(file1, file2, shallow=False)
+compare_files: Callable[[Path, Path], bool] = lambda file1, file2: cmp(
+    file1, file2, shallow=False
+)
 
 
 # Given the `ast` output of a pass and a test program (root) name,
 # runs the interpreter on the program and compares the output to the
 # expected "golden" output.
-def test_pass(passname, interp, program_root, ast, compiler_name) -> bool:
-    input_file = program_root + ".in"
-    output_file = program_root + ".out"
+def test_pass(passname, interp, program_root, _ast, compiler_name) -> int:
+    input_file = Path(program_root + ".in")
+    output_file = Path(program_root + ".out")
+    golden_file = Path(program_root + ".golden")
     stdin = sys.stdin
     stdout = sys.stdout
     sys.stdin = open(input_file, "r")
     sys.stdout = open(output_file, "w")
-    interp(ast)
+    interp(_ast)
     sys.stdin = stdin
     sys.stdout = stdout
-    ensure_final_newline(program_root + '.out')
-    ensure_final_newline(program_root + '.golden')
-    result = compare_files(output_file, program_root + ".golden")
+    ensure_final_newline(output_file)
+    ensure_final_newline(golden_file)
+    result = compare_files(output_file, golden_file)
     if result:
         trace(
             "compiler "
@@ -652,45 +1040,47 @@ def test_pass(passname, interp, program_root, ast, compiler_name) -> bool:
             + program_root
             + "\n"
         )
-        output = open(program_root + ".out").read()
-        expected = open(program_root + ".golden").read()
+        output = open(output_file).read()
+        expected = open(golden_file).read()
         print("Output: " + output)
-        print("Expected: "+ expected)
+        print("Expected: " + expected)
         return 0
 
 
-def validate_tests(lang: str, interp) -> bool:
-    '''check if all tests for `lang` work with `interp`'''
+def validate_tests(path: Path, lang: str, interp) -> bool:
+    """check if all tests for `lang` work with `interp`"""
     test_count = 0
     success_count = 0
-    tests = get_all_tests_for(lang)
+    tests = get_all_tests_for(path)
     for test_filename in tests:
-        program_root = test_filename.split('.')[0]
+        program_root = str(test_filename).split(".")[0]
         with open(test_filename) as source:
-            program = parse(source.read())
+            program = ast.parse(source.read())
         test_count += 1
-        success_count += test_pass('--', interp, program_root, program, lang)
+        success_count += test_pass("--", interp, program_root, program, lang)
     return test_count == success_count
 
 
 def compile_and_test(
+    program_filename: Path,
     compiler,
-    compiler_name,
+    compiler_name: str,
     type_check_P,
     interp_P,
     type_check_C,
     interp_C,
-    program_filename,
 ):
-    def execute_pass(passname: str, program, interp= interp_P, type_check= None):
+    def execute_pass(
+        passname: str, program: ast.Module, interp=interp_P, type_check=None
+    ):
         nonlocal total_passes, successful_passes
         if hasattr(compiler, passname):
-            trace('\n#' + passname + '\n')
+            trace("\n#" + passname + "\n")
             if type_check:
                 type_check(program)
             program_out = getattr(compiler, passname)(program)
             trace(program_out)
-            trace('')
+            trace("")
             total_passes += 1
             successful_passes += test_pass(
                 passname, interp, program_root, program_out, compiler_name
@@ -703,22 +1093,22 @@ def compile_and_test(
     successful_passes = 0
     from interp_x86.eval_x86 import interp_x86
 
-    program_root = program_filename.split('.')[0]
+    program_root = str(program_filename).split(".")[0]
     with open(program_filename) as source:
-        program = parse(source.read())
+        program = ast.parse(source.read())
 
-    trace('\n# source program\n')
+    trace("\n# source program\n")
     trace(program)
-    trace('')
+    trace("")
 
-    program = execute_pass('shrink', program)
-    program = execute_pass('reveal_functions', program, type_check= type_check_P)
-    program = execute_pass('limit_functions', program, type_check= type_check_P)
-    program = execute_pass('resolve', program, type_check= type_check_P)
-    program = execute_pass('check_bounds', program, type_check= type_check_P)
-    program = execute_pass('expose_allocation', program, type_check= type_check_P)
-    program = execute_pass('remove_complex_operands', program)
-    program = execute_pass('explicate_control', program, interp= interp_C)
+    program = execute_pass("shrink", program)
+    program = execute_pass("reveal_functions", program, type_check=type_check_P)
+    program = execute_pass("limit_functions", program, type_check=type_check_P)
+    program = execute_pass("resolve", program, type_check=type_check_P)
+    program = execute_pass("check_bounds", program, type_check=type_check_P)
+    program = execute_pass("expose_allocation", program, type_check=type_check_P)
+    program = execute_pass("remove_complex_operands", program)
+    program = execute_pass("explicate_control", program, interp=interp_C)
 
     if type_check_C:
         trace("\n**********\n type check C \n**********\n")
@@ -729,7 +1119,7 @@ def compile_and_test(
     trace(pseudo_x86)
     trace("")
     total_passes += 1
-    test_x86 = False # doesn't know about GC!
+    test_x86 = False  # doesn't know about GC!
     if test_x86:
         successful_passes += test_pass(
             "select instructions", interp_x86, program_root, pseudo_x86, compiler_name
@@ -755,129 +1145,142 @@ def compile_and_test(
             "patch instructions", interp_x86, program_root, x86, compiler_name
         )
 
-    trace('\n# prelude and conclusion\n')
+    trace("\n# prelude and conclusion\n")
     final_program = compiler.prelude_and_conclusion(x86)
     trace(final_program)
     trace("")
-    
-    x86_filename = program_root + ".s"
+
+    x86_filename = Path(program_root + ".s")
     with open(x86_filename, "w") as dest:
         dest.write(str(final_program))
-        
+
     total_passes += 1
-        
+
+    input_file = Path(program_root + ".in")
+    output_file = Path(program_root + ".out")
+    golden_file = Path(program_root + ".golden")
     # Run the final x86 program
     emulate_x86 = False
     if emulate_x86:
         stdin = sys.stdin
         stdout = sys.stdout
-        sys.stdin = open(program_root + '.in', 'r')
-        sys.stdout = open(program_root + '.out', 'w')
+        sys.stdin = open(input_file, "r")
+        sys.stdout = open(output_file, "w")
         interp_x86(final_program)
         sys.stdin = stdin
         sys.stdout = stdout
     else:
-        os.system('gcc runtime.o ' + x86_filename)
-        input_file = program_root + '.in'
-        output_file = program_root + '.out'
-        os.system('./a.out < ' + input_file + ' > ' + output_file)
+        os.system("gcc runtime.o " + str(x86_filename))
+        os.system("./a.out < " + str(input_file) + " > " + str(output_file))
 
-    ensure_final_newline(program_root + '.out')
-    ensure_final_newline(program_root + '.golden')
-    result = compare_files(program_root + ".out", program_root + ".golden")
+    ensure_final_newline(output_file)
+    ensure_final_newline(golden_file)
+    result = compare_files(output_file, golden_file)
     if result:
         successful_passes += 1
         return (successful_passes, total_passes, 1)
     else:
-        print('compiler ' + compiler_name + ', executable failed' \
-              + ' on test ' + program_root)
+        print(
+            "compiler "
+            + compiler_name
+            + ", executable failed"
+            + " on test "
+            + program_root
+        )
         return (successful_passes, total_passes, 0)
 
-def trace_ast_and_concrete(ast):
+
+def trace_ast_and_concrete(_ast):
     trace("concrete syntax:")
-    trace(ast)
+    trace(_ast)
     trace("")
     trace("AST:")
-    trace(repr(ast))    
-    
-# This function compiles the program without any testing
-def compile(compiler, compiler_name, type_check_P, type_check_C,
-            program_filename):
-    program_root = program_filename.split('.')[0]
-    with open(program_filename) as source:
-        program = parse(source.read())
+    trace(repr(_ast))
 
-    trace('\n# type check\n')        
+
+# This function compiles the program without any testing
+def compile(
+    compiler,
+    compiler_name: str,
+    type_check_P,
+    type_check_C,
+    program_filename: Path,
+):
+    program_root = str(program_filename).split(".")[0]
+    with open(program_filename) as source:
+        program = ast.parse(source.read())
+
+    trace("\n# type check\n")
     type_check_P(program)
     trace_ast_and_concrete(program)
-        
-    if hasattr(compiler, 'shrink'):
-        trace('\n# shrink\n')
+
+    if hasattr(compiler, "shrink"):
+        trace("\n# shrink\n")
         program = compiler.shrink(program)
         trace_ast_and_concrete(program)
 
-    if hasattr(compiler, 'uniquify'):
-        trace('\n# uniquify\n')
+    if hasattr(compiler, "uniquify"):
+        trace("\n# uniquify\n")
         program = compiler.uniquify(program)
         trace_ast_and_concrete(program)
-        
-    if hasattr(compiler, 'reveal_functions'):
-        trace('\n# reveal functions\n')
+
+    if hasattr(compiler, "reveal_functions"):
+        trace("\n# reveal functions\n")
         type_check_P(program)
         program = compiler.reveal_functions(program)
         trace_ast_and_concrete(program)
 
-    if hasattr(compiler, 'convert_assignments'):
-        trace('\n# assignment conversion\n')
+    if hasattr(compiler, "convert_assignments"):
+        trace("\n# assignment conversion\n")
         type_check_P(program)
         program = compiler.convert_assignments(program)
         trace_ast_and_concrete(program)
-        
-    if hasattr(compiler, 'convert_to_closures'):
-        trace('\n# closure conversion\n')
+
+    if hasattr(compiler, "convert_to_closures"):
+        trace("\n# closure conversion\n")
         type_check_P(program)
         program = compiler.convert_to_closures(program)
         trace_ast_and_concrete(program)
-        
-    if hasattr(compiler, 'expose_allocation'):
-        trace('\n# expose allocation\n')
+
+    if hasattr(compiler, "expose_allocation"):
+        trace("\n# expose allocation\n")
         type_check_P(program)
         program = compiler.expose_allocation(program)
         trace_ast_and_concrete(program)
-        
-    trace('\n# remove complex\n')
+
+    trace("\n# remove complex\n")
     program = compiler.remove_complex_operands(program)
     trace_ast_and_concrete(program)
-    
-    if hasattr(compiler, 'explicate_control'):
-        trace('\n# explicate control\n')
+
+    if hasattr(compiler, "explicate_control"):
+        trace("\n# explicate control\n")
         program = compiler.explicate_control(program)
         trace_ast_and_concrete(program)
 
     if type_check_C:
         type_check_C(program)
-        
-    trace('\n# select instructions\n')    
+
+    trace("\n# select instructions\n")
     pseudo_x86 = compiler.select_instructions(program)
     trace_ast_and_concrete(pseudo_x86)
-    
-    trace('\n# assign homes\n')    
+
+    trace("\n# assign homes\n")
     almost_x86 = compiler.assign_homes(pseudo_x86)
     trace_ast_and_concrete(almost_x86)
-    
-    trace('\n# patch instructions\n')        
+
+    trace("\n# patch instructions\n")
     x86 = compiler.patch_instructions(almost_x86)
     trace_ast_and_concrete(x86)
 
-    trace('\n# prelude and conclusion\n')
+    trace("\n# prelude and conclusion\n")
     x86 = compiler.prelude_and_conclusion(x86)
     trace_ast_and_concrete(x86)
-    
+
     # Output x86 program to the .s file
-    x86_filename = program_root + ".s"
+    x86_filename = Path(program_root + ".s")
     with open(x86_filename, "w") as dest:
-        dest.write(str(x86))        
-    
+        dest.write(str(x86))
+
 
 # Given a test file name, the name of a language, a compiler, a type
 # checker and interpreter for the language, and an interpeter for the
@@ -885,12 +1288,19 @@ def compile(compiler, compiler_name, type_check_P, type_check_C,
 # checking that the resulting programs produce output that matches the
 # golden file.
 def run_one_test(
-    test, lang, compiler, compiler_name, type_check_P, interp_P, type_check_C, interp_C
+    test: Path,
+    lang: str,
+    compiler,
+    compiler_name: str,
+    type_check_P,
+    interp_P,
+    type_check_C,
+    interp_C,
 ):
     # test_root = test.split(".")[0]
     # test_name = test_root.split("/")[-1]
     return compile_and_test(
-        compiler, compiler_name, type_check_P, interp_P, type_check_C, interp_C, test
+        test, compiler, compiler_name, type_check_P, interp_P, type_check_C, interp_C
     )
 
 
@@ -900,9 +1310,16 @@ def run_one_test(
 # in the directory of for the given language, i.e., all the
 # python files in ./tests/<language>.
 def run_tests(
-    lang, compiler, compiler_name, type_check_P, interp_P, type_check_C, interp_C
-):
-    tests = get_all_tests_for(lang)
+    path: Path,
+    lang: str,
+    compiler,
+    compiler_name: str,
+    type_check_P,
+    interp_P,
+    type_check_C,
+    interp_C,
+) -> None:
+    tests = get_all_tests_for(path)
 
     # Compile and run each test program, comparing output to the golden file.
     successful_passes = 0
@@ -926,18 +1343,28 @@ def run_tests(
         total_tests += 1
 
     # Report the pass/fails
-    print('tests: ' + repr(successful_tests) + '/' + repr(total_tests) \
-          + ' for compiler ' + compiler_name + ' on language ' + lang)
-    print('passes: ' + repr(successful_passes) + '/' + repr(total_passes) \
-          + ' for compiler ' + compiler_name + ' on language ' + lang)
+    print(
+        "tests: "
+        + repr(successful_tests)
+        + "/"
+        + repr(total_tests)
+        + " for compiler "
+        + compiler_name
+        + " on language "
+        + lang
+    )
+    print(
+        "passes: "
+        + repr(successful_passes)
+        + "/"
+        + repr(total_passes)
+        + " for compiler "
+        + compiler_name
+        + " on language "
+        + lang
+    )
 
-def get_all_tests_for(lang):
-    '''Collect all the test program file names for language `lang`.'''
-    homedir = os.getcwd()
-    directory = homedir + '/tests/' + lang + '/'
-    if not os.path.isdir(directory):
-        raise Exception('missing directory for test programs: ' \
-                        + directory)
-    (dirpath, dirnames, filenames) = next(os.walk(directory))
-    tests = [dirpath + t for t in filenames if is_python_extension(t)]
-    return tests
+
+def get_all_tests_for(path: Path):
+    """Collect all the test program file names for language `lang`."""
+    return list(path.glob("*.py"))


### PR DESCRIPTION
This pull request includes enhancements to test runner, namely `run-tests.py` and some other auxiliary changes.

## `run-tests.py`

`run-tests.py` file is now a CLI tool, which accepts multiple arguments:

```
$ python run-tests.py --help                                                                                                                                                                                            on git:test-runner| o
Usage: run-tests.py [OPTIONS] PATH

  Runs test(s) found in PATH. If PATH is a directory, script will try to find
  and run all the tests in it. If it's a file, script will try to run only
  that single test.

Options:
  -l, --lang TEXT                Lang to use  [required]
  -c, --compiler TEXT            Compiler to use  [required]
  --trace / --no-trace           Enable tracing  [default: no-trace]
  -r, --recursion-limit INTEGER  Change the recursion limit  [default: 10000]
  --help                         Show this message and exit.
```

As explained in the help output, if `PATH` is a directory, it tries to run all the tests within it:

```
$ python run-tests.py -l var -c var tests/var                                                                                                                                                                           on git:test-runner| o
tests: 4/4 for compiler var on language var
passes: 28/40 for compiler var on language var
```
```
$ python run-tests.py -l fun -c fun tests/fun                                                                                                                                                                           on git:test-runner| o
tests: 5/5 for compiler fun on language fun
passes: 35/50 for compiler fun on language fun
```

However, if `PATH` is a file (has to be the test file itself, not `.in` or `.golden`), it tries to run that test specifically:

```
$ python run-tests.py -l var -c var tests/var/add.py                                                                                                                                                                    on git:test-runner| o
test file: tests/var/add.py
tests: 1 successful test for compiler var on language var
passes: 7/10 for compiler var on language var
```
```
$ python run-tests.py -l fun -c fun tests/fun/ifreturn.py                                                                                                                                                               on git:test-runner| o
test file: tests/fun/ifreturn.py
tests: 1 successful test for compiler fun on language fun
passes: 7/10 for compiler fun on language fun
```

Also `--trace` and `--no-trace` parameters have been introduced to enable or disable tracing (`--no-trace` is the default):

```
$ python run-tests.py -l var -c var --trace tests/var/add.py                                                                                                                                                            on git:test-runner| o

# source program

    print((40 + 2))



#shrink

    def main() -> int:
      print((40 + 2))
      return 0



compiler var success on pass shrink on test
tests/var/add


#reveal_functions

    def main() -> int:
      print((40 + 2))
      return 0



compiler var success on pass reveal_functions on test
tests/var/add


#limit_functions

    def main() -> int:
      print((40 + 2))
      return 0



compiler var success on pass limit_functions on test
tests/var/add


#expose_allocation

    def main() -> int:
      print((40 + 2))
      return 0



compiler var success on pass expose_allocation on test
tests/var/add


#remove_complex_operands

    def main() -> int:
      atom.0 = (40 + 2)
      print(atom.0)
      return 0



compiler var success on pass remove_complex_operands on test
tests/var/add


#explicate_control

  def main() -> int:
_mainstart:
      atom.0 = (40 + 2)
      print(atom.0)
      expl.1 = 0
      return expl.1




compiler var success on pass explicate_control on test
tests/var/add


**********
 type check C
**********


**********
 select
**********

  def main() -> int:
_mainconclusion:
      popq %rbp
      retq
_mainstart:
      movq $40, atom.0
      addq $2, atom.0
      movq atom.0, %rdi
      callq _print_int
      movq $0, expl.1
      movq expl.1, %rax
      jmp _mainconclusion
_main:
      pushq %rbp
      movq %rsp, %rbp
      movq $16384, %rdi
      movq $16384, %rsi
      callq _initialize
      movq _rootstack_begin(%rip), %r15
      movq $0, 0(%r15)
      jmp _mainstart




**********
 assign
**********

  def main() -> int:
_mainconclusion:
      popq %rbp
      retq
_mainstart:
      movq $40, %rcx
      addq $2, %rcx
      movq %rcx, %rdi
      callq _print_int
      movq $0, %rcx
      movq %rcx, %rax
      jmp _mainconclusion
_main:
      pushq %rbp
      movq %rsp, %rbp
      movq $16384, %rdi
      movq $16384, %rsi
      callq _initialize
      movq _rootstack_begin(%rip), %r15
      movq $0, 0(%r15)
      jmp _mainstart




**********
 patch
**********

  def main() -> int:
_mainconclusion:
      popq %rbp
      retq
_mainstart:
      movq $40, %rcx
      addq $2, %rcx
      movq %rcx, %rdi
      callq _print_int
      movq $0, %rcx
      movq %rcx, %rax
      jmp _mainconclusion
_main:
      pushq %rbp
      movq %rsp, %rbp
      movq $16384, %rdi
      movq $16384, %rsi
      callq _initialize
      movq _rootstack_begin(%rip), %r15
      movq $0, 0(%r15)
      jmp _mainstart




# prelude and conclusion

	.align 16
_mainconclusion:
    popq %rbp
    retq

	.align 16
_mainstart:
    movq $40, %rcx
    addq $2, %rcx
    movq %rcx, %rdi
    callq _print_int
    movq $0, %rcx
    movq %rcx, %rax
    jmp _mainconclusion

	.globl _main
	.align 16
_main:
    pushq %rbp
    movq %rsp, %rbp
    movq $16384, %rdi
    movq $16384, %rsi
    callq _initialize
    movq _rootstack_begin(%rip), %r15
    jmp _mainstart




test file: tests/var/add.py
tests: 1 successful test for compiler var on language var
passes: 7/10 for compiler var on language var
```