### PR TITLE
Conversion of label_name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/lintandtest.yml
+++ b/.github/workflows/lintandtest.yml
@@ -1,0 +1,28 @@
+name: Lint and test
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        continue-on-error: true
+        with:
+          options: "--check --verbose --target-version py310"
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: |
+         gcc -c -g -std=c99 runtime.c
+         pip install -r requirements.txt
+         python run-tests.py -l fun -c fun tests/fun
+         python run-tests.py -l if -c if tests/lif
+         python run-tests.py -l regalloc -c regalloc tests/regalloc
+         python run-tests.py -l tup -c tup tests/tuples
+         python run-tests.py -l var -c var tests/var

--- a/compiler.py
+++ b/compiler.py
@@ -314,12 +314,12 @@ class Compiler:
                     If(
                         Compare(
                             BinOp(
-                                GlobalValue(Label("free_ptr").name),
+                                GlobalValue(Label("free_ptr")),
                                 Add(),
                                 Constant(bytesreq),
                             ),
                             [Lt()],
-                            [GlobalValue(Label("fromspace_end").name)],
+                            [GlobalValue(Label("fromspace_end"))],
                         ),
                         [Expr(Constant(0))],
                         [Collect(bytesreq)],

--- a/compiler.py
+++ b/compiler.py
@@ -314,12 +314,12 @@ class Compiler:
                     If(
                         Compare(
                             BinOp(
-                                GlobalValue(Label("free_ptr")),
+                                GlobalValue(Label("free_ptr").name),
                                 Add(),
                                 Constant(bytesreq),
                             ),
                             [Lt()],
-                            [GlobalValue(Label("fromspace_end"))],
+                            [GlobalValue(Label("fromspace_end").name)],
                         ),
                         [Expr(Constant(0))],
                         [Collect(bytesreq)],

--- a/interp_Cfun.py
+++ b/interp_Cfun.py
@@ -19,7 +19,7 @@ class InterpCfun(InterpCtup):
                 next_label = name + "start"
                 ret = None
                 while True:
-                    r = self.interp_stmts(blocks[utils.label_name(next_label)], new_env)
+                    r = self.interp_stmts(blocks[utils.Label(next_label)], new_env)
                     match r:
                         case utils.Goto(label):
                             next_label = label

--- a/interp_Cif.py
+++ b/interp_Cif.py
@@ -1,26 +1,26 @@
-from ast import *
+import ast
 from interp_Lif import InterpLif
-from utils import *
+import utils
+
 
 class InterpCif(InterpLif):
+    def interp_stmts(self, ss, env):
+        if len(ss) == 0:
+            return
+        match ss[0]:
+            case ast.Return(value):
+                return ast.Return(self.interp_exp(value, env))
+            case utils.Goto(label):
+                return utils.Goto(label)
+                # return self.interp_stmts(self.blocks[label_name(label)], env)
+            case _:
+                return super().interp_stmts(ss, env)
 
-  def interp_stmts(self, ss, env):
-    if len(ss) == 0:
-        return
-    match ss[0]:
-      case Return(value):
-        return Return(self.interp_exp(value, env))
-      case Goto(label):
-        return Goto(label)
-        # return self.interp_stmts(self.blocks[label_name(label)], env)
-      case _:
-        return super().interp_stmts(ss, env)
-    
-  def interp(self, p):
-    match p:
-      case CProgram(blocks):
-        env = {}
-        self.blocks = blocks
-        r = self.interp_stmts(blocks[label_name('start')], env)
-        while isinstance(r, Goto):
-          r = self.interp_stmts(self.blocks[label_name(r.label)], env)
+    def interp(self, p):
+        match p:
+            case utils.CProgram(blocks):
+                env = {}
+                self.blocks = blocks
+                r = self.interp_stmts(blocks[utils.Label("start")], env)
+                while isinstance(r, utils.Goto):
+                    r = self.interp_stmts(self.blocks[utils.Label(r.label)], env)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pathspec==0.9.0
 platformdirs==2.5.2
 tomli==2.0.1
 typing_extensions==4.2.0
-graphviz
+graphviz==0.20

--- a/utils.py
+++ b/utils.py
@@ -794,7 +794,7 @@ class Begin(ast.expr):
 
 @dataclass
 class GlobalValue(ast.expr):
-    name: str
+    name: Label
 
     def __str__(self):
         return str(self.name)

--- a/utils.py
+++ b/utils.py
@@ -1,19 +1,39 @@
-from collections import UserString
 import os
 from pathlib import Path
 import sys
 import ast
 from dataclasses import dataclass
+from types import NotImplementedType
 from typing import Callable, Dict, List
 from filecmp import cmp
-from typing_extensions import Self
 
 ################################################################################
 # Labels
 ################################################################################
-class Label(str):
-    def __new__(cls: type[Self], seq: object) -> Self:
-        return str.__new__(cls, "_" + seq if sys.platform == "darwin" else seq)
+LABEL_PREPEND: str = "_" if sys.platform == "darwin" else ""
+
+
+@dataclass(frozen=True)
+class Label:
+    name: str
+
+    def __init__(self, _name: str) -> None:
+        object.__setattr__(self, "name", LABEL_PREPEND + _name)
+
+    def __add__(self, other) -> str | NotImplementedType:
+        if isinstance(other, str):
+            return self.name + other
+        else:
+            return NotImplemented
+
+    def __radd__(self, other) -> str | NotImplementedType:
+        if isinstance(other, str):
+            return other + self.name
+        else:
+            return NotImplemented
+
+    def __str__(self) -> str:
+        return self.name
 
 
 # label_name: Callable[[str], str] = (

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,30 @@
+from collections import UserString
 import os
 from pathlib import Path
 import sys
 import ast
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Dict, List
 from filecmp import cmp
+from typing_extensions import Self
+
+################################################################################
+# Labels
+################################################################################
+class Label(str):
+    def __new__(cls: type[Self], seq: object) -> Self:
+        return str.__new__(cls, "_" + seq if sys.platform == "darwin" else seq)
+
+
+# label_name: Callable[[str], str] = (
+#     (lambda n: "_" + n) if sys.platform == "darwin" else (lambda n: n)
+# )
+
+# def label_name(n: str) -> str:
+#     if sys.platform == "darwin":
+#         return '_' + n
+#     else:
+#         return n
 
 ################################################################################
 # repr for classes in the ast module
@@ -912,13 +932,13 @@ block_id = 0
 
 
 def create_block(
-    stmts: list[ast.stmt], basic_blocks: dict[str, list[ast.stmt]]
+    stmts: List[ast.stmt], basic_blocks: Dict[Label, list[ast.stmt]]
 ) -> Goto:
     "stuff statments into a new basic block; return a jump to it"
     global block_id
     label = "block" + str(block_id)
     block_id += 1
-    basic_blocks[label_name(label)] = stmts
+    basic_blocks[Label(label)] = stmts
     return Goto(label)
 
 
@@ -951,17 +971,6 @@ def bool2int(b):
         return 1
     else:
         return 0
-
-
-label_name: Callable[[str], str] = (
-    (lambda n: "_" + n) if sys.platform == "darwin" else (lambda n: n)
-)
-
-# def label_name(n: str) -> str:
-#     if sys.platform == "darwin":
-#         return '_' + n
-#     else:
-#         return n
 
 
 def ast_loc(obj: ast.AST):

--- a/x86_ast.py
+++ b/x86_ast.py
@@ -1,212 +1,296 @@
 from typing import List
-from utils import label_name, indent, dedent, indent_stmt
+from utils import Label, indent, dedent, indent_stmt
+
 
 class X86Program:
     __match_args__ = ("body",)
+
     def __init__(self, body):
         self.body = body
+
     def __str__(self):
-        result = ''
+        result = ""
         if type(self.body) == dict:
-            for (l,ss) in self.body.items():
-                if l == label_name('main'):
-                    result += '\t.globl ' + label_name('main') + '\n'
-                result += '\t.align 16\n'
-                result += l + ':\n'
+            for (l, ss) in self.body.items():
+                if l == Label("main"):
+                    result += "\t.globl " + Label("main") + "\n"
+                result += "\t.align 16\n"
+                result += l + ":\n"
                 indent()
-                result += ''.join([str(s) for s in ss]) + '\n'
+                result += "".join([str(s) for s in ss]) + "\n"
                 dedent()
         else:
-            result += '\t.globl ' + label_name('main') + '\n' + \
-                      label_name('main') + ':\n'
+            result += "\t.globl " + Label("main") + "\n" + Label("main") + ":\n"
             indent()
-            result += ''.join([str(s) for s in self.body])
+            result += "".join([str(s) for s in self.body])
             dedent()
-        result += '\n'
+        result += "\n"
         return result
+
     def __repr__(self):
-        return 'X86Program(' + repr(self.body) + ')'
+        return "X86Program(" + repr(self.body) + ")"
+
 
 class X86ProgramDefs:
     __match_args__ = ("defs",)
+
     def __init__(self, defs):
         self.defs = defs
+
     def __str__(self):
-        return '\n'.join([str(d) for d in self.defs])
+        return "\n".join([str(d) for d in self.defs])
+
     def __repr__(self):
-        return 'X86ProgramDefs(' + repr(self.defs) + ')'
-    
-class instr: ...
-class arg: ...
-class location(arg): ...
-    
+        return "X86ProgramDefs(" + repr(self.defs) + ")"
+
+
+class instr:
+    ...
+
+
+class arg:
+    ...
+
+
+class location(arg):
+    ...
+
+
 class Instr(instr):
     instr: str
     args: List[arg]
-    
+
     __match_args__ = ("instr", "args")
+
     def __init__(self, instr, args):
         self.instr = instr
         self.args = args
+
     def source(self):
         return self.args[0]
+
     def target(self):
         return self.args[-1]
+
     def __str__(self):
-        return indent_stmt() + self.instr + ' ' + ', '.join(str(a) for a in self.args) + '\n'
+        return (
+            indent_stmt()
+            + self.instr
+            + " "
+            + ", ".join(str(a) for a in self.args)
+            + "\n"
+        )
+
     def __repr__(self):
-        return 'Instr(' + repr(self.instr) + ', ' + repr(self.args) + ')'
-    
+        return "Instr(" + repr(self.instr) + ", " + repr(self.args) + ")"
+
+
 class Callq(instr):
     __match_args__ = ("func", "num_args")
+
     def __init__(self, func, num_args):
         self.func = func
         self.num_args = num_args
+
     def __str__(self):
-        return indent_stmt() + 'callq' + ' ' + self.func + '\n'
+        return indent_stmt() + "callq" + " " + self.func + "\n"
+
     def __repr__(self):
-        return 'Callq(' + repr(self.func) + ', ' + repr(self.num_args) + ')'
+        return "Callq(" + repr(self.func) + ", " + repr(self.num_args) + ")"
+
 
 class IndirectCallq(instr):
     __match_args__ = ("func", "num_args")
+
     def __init__(self, func, num_args):
         self.func = func
         self.num_args = num_args
+
     def __str__(self):
-        return indent_stmt() + 'callq' + ' *' + str(self.func) + '\n'
+        return indent_stmt() + "callq" + " *" + str(self.func) + "\n"
+
     def __repr__(self):
-        return 'IndirectCallq(' + repr(self.func) + ', ' + repr(self.num_args) + ')'
-    
+        return "IndirectCallq(" + repr(self.func) + ", " + repr(self.num_args) + ")"
+
+
 class JumpIf(instr):
     cc: str
     label: str
-    
+
     __match_args__ = ("cc", "label")
+
     def __init__(self, cc, label):
         self.cc = cc
         self.label = label
+
     def __str__(self):
-        return indent_stmt() + 'j' + self.cc + ' ' + self.label + '\n'
+        return indent_stmt() + "j" + self.cc + " " + self.label + "\n"
+
     def __repr__(self):
-        return 'JumpIf(' + repr(self.cc) + ', ' + repr(self.label) + ')'
+        return "JumpIf(" + repr(self.cc) + ", " + repr(self.label) + ")"
+
 
 class Jump(instr):
     label: str
-    
+
     __match_args__ = ("label",)
+
     def __init__(self, label):
         self.label = label
+
     def __str__(self):
-        return indent_stmt() + 'jmp ' + self.label + '\n'
+        return indent_stmt() + "jmp " + self.label + "\n"
+
     def __repr__(self):
-        return 'Jump(' + repr(self.label) + ')'
+        return "Jump(" + repr(self.label) + ")"
+
 
 class IndirectJump(instr):
     __match_args__ = ("target",)
+
     def __init__(self, target):
         self.target = target
+
     def __str__(self):
-        return indent_stmt() + 'jmp *' + str(self.target) + '\n'
+        return indent_stmt() + "jmp *" + str(self.target) + "\n"
+
     def __repr__(self):
-        return 'IndirectJump(' + repr(self.target) + ')'
-    
+        return "IndirectJump(" + repr(self.target) + ")"
+
+
 class TailJump(instr):
-    __match_args__ = ("func","arity")
+    __match_args__ = ("func", "arity")
+
     def __init__(self, func, arity):
         self.func = func
         self.arity = arity
+
     def __str__(self):
-        return indent_stmt() + 'tailjmp ' + str(self.func) + '\n'
+        return indent_stmt() + "tailjmp " + str(self.func) + "\n"
+
     def __repr__(self):
-        return 'TailJump(' + repr(self.func) + ',' + repr(self.arity) + ')'
-    
+        return "TailJump(" + repr(self.func) + "," + repr(self.arity) + ")"
+
+
 class Variable(location):
     __match_args__ = ("id",)
+
     def __init__(self, id):
         self.id = id
+
     def __str__(self):
         return self.id
+
     def __repr__(self):
-        return 'Variable(' + repr(self.id) + ')'
+        return "Variable(" + repr(self.id) + ")"
+
     def __eq__(self, other):
         if isinstance(other, Variable):
             return self.id == other.id
         else:
             return False
+
     def __hash__(self):
         return hash(self.id)
 
+
 class Immediate(arg):
     __match_args__ = ("value",)
+
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
-        return '$' +  str(self.value)
+        return "$" + str(self.value)
+
     def __repr__(self):
-        return 'Immediate(' +  repr(self.value) + ')'
+        return "Immediate(" + repr(self.value) + ")"
+
     def __eq__(self, other):
         if isinstance(other, Immediate):
             return self.value == other.value
         else:
             return False
+
     def __hash__(self):
         return hash(self.value)
-    
+
+
 class Reg(location):
     __match_args__ = ("id",)
+
     def __init__(self, id):
         self.id = id
+
     def __str__(self):
-        return '%' + self.id
+        return "%" + self.id
+
     def __repr__(self):
-        return 'Reg(' + repr(self.id) + ')'
+        return "Reg(" + repr(self.id) + ")"
+
     def __eq__(self, other):
         if isinstance(other, Reg):
             return self.id == other.id
         else:
             return False
+
     def __hash__(self):
         return hash(self.id)
-        
+
+
 class ByteReg(arg):
     __match_args__ = ("id",)
+
     def __init__(self, id):
         self.id = id
+
     def __str__(self):
-        return '%' + self.id
+        return "%" + self.id
+
     def __repr__(self):
-        return 'ByteReg(' + repr(self.id) + ')'
+        return "ByteReg(" + repr(self.id) + ")"
+
     def __eq__(self, other):
         if isinstance(other, ByteReg):
             return self.id == other.id
         else:
             return False
+
     def __hash__(self):
         return hash(self.id)
-        
+
+
 class Deref(arg):
     __match_args__ = ("reg", "offset")
+
     def __init__(self, reg, offset):
         self.reg = reg
         self.offset = offset
+
     def __str__(self):
-        return str(self.offset) + '(%' + self.reg + ')'
+        return str(self.offset) + "(%" + self.reg + ")"
+
     def __repr__(self):
-        return 'Deref(' + repr(self.reg) + ', ' + repr(self.offset) + ')'
+        return "Deref(" + repr(self.reg) + ", " + repr(self.offset) + ")"
+
     def __eq__(self, other):
         if isinstance(other, Deref):
             return self.reg == other.reg and self.offset == other.offset
         else:
             return False
+
     def __hash__(self):
         return hash((self.reg, self.offset))
 
+
 class Global(arg):
     __match_args__ = ("name",)
+
     def __init__(self, name):
         self.name = name
+
     def __str__(self):
         return str(self.name) + "(%rip)"
+
     def __repr__(self):
-        return 'Global(' + repr(self.name) + ')'
-    
+        return "Global(" + repr(self.name) + ")"

--- a/x86_ast.py
+++ b/x86_ast.py
@@ -13,14 +13,16 @@ class X86Program:
         if type(self.body) == dict:
             for (l, ss) in self.body.items():
                 if l == Label("main"):
-                    result += "\t.globl " + Label("main") + "\n"
+                    result += "\t.globl " + Label("main").name + "\n"
                 result += "\t.align 16\n"
                 result += l + ":\n"
                 indent()
                 result += "".join([str(s) for s in ss]) + "\n"
                 dedent()
         else:
-            result += "\t.globl " + Label("main") + "\n" + Label("main") + ":\n"
+            result += (
+                "\t.globl " + Label("main").name + "\n" + Label("main").name + ":\n"
+            )
             indent()
             result += "".join([str(s) for s in self.body])
             dedent()


### PR DESCRIPTION
With these commits, `label_name` function has been converted to a class named `Label`, extended from the original `str`. As it's just a subclass of `str`, it can be (and is) used as a drop-in replacement of `label_name` throughout the code. Modified files have been formatted with [`psf/black`](https://github.com/psf/black) as well.

This branch has been branched from `error-reporting`, so includes it's changes as well.